### PR TITLE
expose 8082 and 8083 ports for nexus in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,8 @@ services:
             - nexus_data:/nexus-data
         ports:
             - 8081:8081
+            - 8082:8082
+            - 8083:8083
         networks:
             - att-net
 volumes:


### PR DESCRIPTION
The Docker repo requires 2 different ports. We are going to use 8082 for pull from the proxy repo and 8083 for pull and push to the private repo.